### PR TITLE
Mark scroll listener as passive

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -11,4 +11,4 @@ window.addEventListener("scroll", () => {
   let scrollPercent = scrollTop / (docHeight - winHeight);
   let scrollPercentRounded = Math.round(scrollPercent * 100);
   document.title = `(${scrollPercentRounded}%) ${originalTitle}`;
-});
+}, { passive: true });


### PR DESCRIPTION
You probably also don't want to `console.log` there because that's noisy, it's fine to `console.log` in the background page of course.

Passive listeners don't block layout by not letting events call `preventDefault`, see [mdn](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners). 